### PR TITLE
feat: scale mvp

### DIFF
--- a/camunda-scaling-operator/api/v1alpha1/zeebeautoscaler_types.go
+++ b/camunda-scaling-operator/api/v1alpha1/zeebeautoscaler_types.go
@@ -43,10 +43,14 @@ type ZeebeAutoscalerStatus struct {
 	// Conditions holds the information on the last operations on Zeebe that can be useful during scaling
 	// +kubebuilder:validation:Optional
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
+
+	Replicas int32  `json:"replicas"`
+	Selector string `json:"selector"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 
 // ZeebeAutoscaler is the Schema for the zeebeautoscalers API
 type ZeebeAutoscaler struct {

--- a/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
+++ b/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
@@ -132,9 +132,21 @@ spec:
                   the controller.
                 format: int64
                 type: integer
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
+            required:
+            - replicas
+            - selector
             type: object
         type: object
     served: true
     storage: true
     subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/camunda-scaling-operator/config/rbac/role.yaml
+++ b/camunda-scaling-operator/config/rbac/role.yaml
@@ -19,6 +19,13 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - statefulsets/scale
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - apps
+  resources:
   - statefulsets/status
   verbs:
   - get

--- a/camunda-scaling-operator/config/rbac/role.yaml
+++ b/camunda-scaling-operator/config/rbac/role.yaml
@@ -5,6 +5,24 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets/status
+  verbs:
+  - get
+- apiGroups:
   - camunda.sijoma.dev
   resources:
   - zeebeautoscalers

--- a/camunda-scaling-operator/config/samples/camunda_v1alpha1_zeebeautoscaler.yaml
+++ b/camunda-scaling-operator/config/samples/camunda_v1alpha1_zeebeautoscaler.yaml
@@ -2,8 +2,8 @@ apiVersion: camunda.sijoma.dev/v1alpha1
 kind: ZeebeAutoscaler
 metadata:
   name: zeebeautoscaler-sample
+  namespace: camunda-platform
 spec:
-  minReplicas: 1
-  maxReplicas: 2
+  replicas: 3
   zeebeRef:
-    name: my-zeebe
+    name: camunda-platform-zeebe


### PR DESCRIPTION
This allows to do the following. 

Run this command:
kubectl scale zeebeautoscalers.camunda.sijoma.dev zeebeautoscaler-sample --replicas 3

The Zeebe statefulset will then be scaled accordingly. It misses the API call towards Zeebe to make the scaling actually work. 

In addition, the status contains the `replicas` & `selector` field. This is supposedly needed to let the HPA object control it. 

> The scale subresource is enabled via +kubebuilder:subresource:scale. When enabled, users will be able to use kubectl scale with your resource. If the selectorpath argument pointed to the string form of a label selector, the HorizontalPodAutoscaler will be able to autoscale your resource.

https://book.kubebuilder.io/reference/generating-crd.html#scale