### PR TITLE
feat: hpa example

### DIFF
--- a/deploy/local/hpa-example/hpa.yaml
+++ b/deploy/local/hpa-example/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: camunda-hpa
+  namespace: camunda-platform
+spec:
+  minReplicas: 3
+  maxReplicas: 7
+  metrics:
+    - resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 2
+      type: Resource
+  scaleTargetRef:
+    apiVersion: camunda.sijoma.dev/v1alpha1
+    kind: ZeebeAutoscaler
+    name: zeebeautoscaler-sample


### PR DESCRIPTION
Stacked PR on scale mvp.

This sets up a HPA with a CPU utilisation target. Everything seems to work. The metrics don't exist as we haven't deployed metrics server so that's expected. 

Output of kubectl get hpa camunda-hpa
<img width="934" alt="image" src="https://github.com/user-attachments/assets/25269141-a62b-4d24-bff6-11108d373eb6">

Output of: kubectl describe hpa camunda-hpa
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/cf26adcc-e453-4cca-b41e-70555eb5ff1a">

