### PR TITLE
feat: conditions & printcolumns

### DIFF
--- a/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
+++ b/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
@@ -14,7 +14,14 @@ spec:
     singular: zeebeautoscaler
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='ReadyToScale')].status
+      name: Ready To Scale
+      type: string
+    - jsonPath: .spec.zeebeRef.name
+      name: Target
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ZeebeAutoscaler is the Schema for the zeebeautoscalers API


### PR DESCRIPTION
This adds the condition: `ReadyToScale`

Which has the these two "states". I wouldn't say these are tooo useful. But at least it shows that the Zeebe connection works. If we want to reflect the process more accurately, we would need to set these in a lot more places. Ultimately, I don't think we want that. I just wanted to add some to have the basics in place to give an idea. 

ReadyToScale = true 
```yaml
 - lastTransitionTime: "2024-08-21T19:57:12Z"
    message: Zeebe Topology queried. Found 3 Brokers.
    reason: ZeebeTopologyFound
    status: "True"
    type: ReadyToScale
```
ReadyToScale = false
```yaml
- lastTransitionTime: "2024-08-21T19:59:27Z"
    message: 'Topology change pending: Status: IN_PROGRESS'
    reason: ZeebePendingOperation
    status: "False"
    type: ReadyToScale
```

Printcolumns are also added.
<img width="613" alt="image" src="https://github.com/user-attachments/assets/7f4c1082-d863-47ea-a488-4864182a12b1">
