### PR TITLE
feat: add monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,32 @@
 ### Kind Dev environment
 
-setup-dev:
+setup-kind:
 	kind create cluster --name hackdays --config deploy/local/kind-cluster.yaml
+
+deploy-stack:
+	$(MAKE) deploy-metrics-server
+## Needs to be run multiplce times due to CRDs
+	$(MAKE) deploy-monitoring
+	sleep 5
+	$(MAKE) deploy-monitoring
+	sleep 5
+	$(MAKE) deploy-monitoring
+# Exchange with deploy without build
+	$(MAKE) -C camunda-scaling-operator deploy-test-env
 	$(MAKE) deploy-camunda
 
 deploy-camunda:
 	kustomize build --enable-helm ./deploy/local/camunda | kubectl apply -f -
 
+## Needs to be run twice due to CRDs
+deploy-monitoring:
+	kustomize build --enable-helm ./deploy/local/monitoring | kubectl apply --server-side -f -
+
+deploy-metrics-server:
+	kustomize build ./deploy/local/metrics-server | kubectl apply --server-side -f -
+
 undeploy-camunda:
 	kustomize build --enable-helm ./deploy/local/camunda | kubectl delete -f -
-
-# TODO: use camunda-scaling-operator/Makefile:148
-# deploy-operator:
-
 
 teardown:
 	kind delete cluster --name hackdays

--- a/deploy/local/camunda/kustomization.yaml
+++ b/deploy/local/camunda/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 # Only enable if you have the camunda-scaling-operator installed
 #  - camunda_v1alpha1_zeebeautoscaler.yaml
 # Only enable if you have prometheus installed
-#  - zeebe-svc-monitor.yaml
+  - zeebe-svc-monitor.yaml
 
 generators:
   - camunda-chart.yaml

--- a/deploy/local/metrics-server/kustomization.yaml
+++ b/deploy/local/metrics-server/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.7.2/components.yaml
+
+## Only required for KIND setups
+patches:
+  - target:
+      version: v1
+      kind: Deployment
+      name: metrics-server
+      namespace: kube-system
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --kubelet-insecure-tls

--- a/deploy/local/monitoring/adapter-chart.yaml
+++ b/deploy/local/monitoring/adapter-chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: prom-adapter
+name: prometheus-adapter
+repo: https://prometheus-community.github.io/helm-charts
+version: 4.11.0
+# NOTE: We should use "nameTemplate" not "releaseName" to keep the names as same as using Helm CLI.
+nameTemplate: adapter
+namespace: prom-adapter
+IncludeCRDs: true
+valuesMerge: merge
+valuesFile: adapter-values.yaml
+skipTests: true
+apiVersions:
+  - apiregistration.k8s.io/v1

--- a/deploy/local/monitoring/adapter-values.yaml
+++ b/deploy/local/monitoring/adapter-values.yaml
@@ -1,0 +1,19 @@
+# Url to access prometheus
+prometheus:
+  # Value is templated
+  url: http://prometheus-operated.monitoring.svc
+  port: 9090
+
+rules:
+  custom:
+    - seriesQuery: zeebe_dropped_request_count_created{namespace!="",pod!=""}
+      name:
+        as: ${1}_per_second
+        matches: ^(.*)_created
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[2m])) by (<<.GroupBy>>)

--- a/deploy/local/monitoring/kustomization.yaml
+++ b/deploy/local/monitoring/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespaces.yaml
+
+generators:
+  - monitoring.yaml
+  - adapter-chart.yaml

--- a/deploy/local/monitoring/monitoring.yaml
+++ b/deploy/local/monitoring/monitoring.yaml
@@ -1,0 +1,14 @@
+apiVersion: builtin
+kind: HelmChartInflationGenerator
+metadata:
+  name: monitoring
+name: kube-prometheus-stack
+repo: https://prometheus-community.github.io/helm-charts
+version: 62.1.0
+# NOTE: We should use "nameTemplate" not "releaseName" to keep the names as same as using Helm CLI.
+nameTemplate: prom
+namespace: monitoring
+IncludeCRDs: true
+valuesMerge: merge
+valuesFile: prometheus-values.yaml
+skipTests: true

--- a/deploy/local/monitoring/namespaces.yaml
+++ b/deploy/local/monitoring/namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: prom-adapter

--- a/deploy/local/monitoring/prometheus-values.yaml
+++ b/deploy/local/monitoring/prometheus-values.yaml
@@ -1,0 +1,7 @@
+prometheus:
+  prometheusSpec:
+    # Allow to pickup servicemonitors etc from everywhere
+    podMonitorSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    scrapeConfigSelectorNilUsesHelmValues: false
+    serviceMonitorSelectorNilUsesHelmValues: false


### PR DESCRIPTION
Drowsy monitoring setup on kind with prom-adapter custom rule to get a Zeebe metrics as "per_second". The metric needs to be switched out and is WIP.

But hey: it works locally. So perfect for a live-demo :D. 