### PR TITLE
better api docs & defaults & rest

### DIFF
--- a/camunda-scaling-operator/api/v1alpha1/zeebeautoscaler_types.go
+++ b/camunda-scaling-operator/api/v1alpha1/zeebeautoscaler_types.go
@@ -24,9 +24,10 @@ import (
 
 // ZeebeAutoscalerSpec defines the desired state of ZeebeAutoscaler
 type ZeebeAutoscalerSpec struct {
+	// Replicas the number of Zeebe brokers to deploy
 	Replicas *int32 `json:"replicas,omitempty"`
 
-	// +kubebuilder:default={name:camunda-platform-zeebe,gateway:{serviceName:camunda-platform-zeebe-gateway,port:9600}}
+	// +kubebuilder:default={}
 	ZeebeRef ZeebeRef `json:"zeebeRef,omitempty"`
 }
 
@@ -34,13 +35,19 @@ type ZeebeAutoscalerSpec struct {
 type ZeebeRef struct {
 	// Name of the Zeebe statefulset to scale
 	// +kubebuilder:validation:MinLength=1
-	Name    string  `json:"name,omitempty"`
+	// +kubebuilder:default=camunda-platform-zeebe
+	Name string `json:"name,omitempty"`
+	// +kubebuilder:default={}
 	Gateway Gateway `json:"gateway,omitempty"`
 }
 
 type Gateway struct {
+	// +kubebuilder:default=camunda-platform-zeebe-gateway
+	// ServiceName of the zeebe-gateway, this is used to trigger scaling operations & request topology information
 	ServiceName string `json:"serviceName,omitempty"`
-	Port        int32  `json:"port,omitempty"`
+	// +kubebuilder:default=9600
+	// Port of the zeebe-gateway, needs to expose the management API
+	Port int32 `json:"port,omitempty"`
 }
 
 // ZeebeAutoscalerStatus defines the observed state of ZeebeAutoscaler
@@ -89,6 +96,8 @@ func ZeebePendingTopologyChange(status string) metav1.Condition {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
+// +kubebuilder:printcolumn:name="Desired Replicas",type=string,JSONPath=`.spec.replicas`
+// +kubebuilder:printcolumn:name="Current Replicas",type=string,JSONPath=`.status.replicas`
 // +kubebuilder:printcolumn:name="Ready To Scale",type=string,JSONPath=`.status.conditions[?(@.type=='ReadyToScale')].status`
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.zeebeRef.name`
 

--- a/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
+++ b/camunda-scaling-operator/config/crd/bases/camunda.sijoma.dev_zeebeautoscalers.yaml
@@ -15,6 +15,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Desired Replicas
+      type: string
+    - jsonPath: .status.replicas
+      name: Current Replicas
+      type: string
     - jsonPath: .status.conditions[?(@.type=='ReadyToScale')].status
       name: Ready To Scale
       type: string
@@ -47,25 +53,30 @@ spec:
             description: ZeebeAutoscalerSpec defines the desired state of ZeebeAutoscaler
             properties:
               replicas:
+                description: Replicas the number of Zeebe brokers to deploy
                 format: int32
                 type: integer
               zeebeRef:
-                default:
-                  gateway:
-                    port: 9600
-                    serviceName: camunda-platform-zeebe-gateway
-                  name: camunda-platform-zeebe
+                default: {}
                 description: ZeebeRef references that exists in the same namespace.
                 properties:
                   gateway:
+                    default: {}
                     properties:
                       port:
+                        default: 9600
+                        description: Port of the zeebe-gateway, needs to expose the
+                          management API
                         format: int32
                         type: integer
                       serviceName:
+                        default: camunda-platform-zeebe-gateway
+                        description: ServiceName of the zeebe-gateway, this is used
+                          to trigger scaling operations & request topology information
                         type: string
                     type: object
                   name:
+                    default: camunda-platform-zeebe
                     description: Name of the Zeebe statefulset to scale
                     minLength: 1
                     type: string

--- a/deploy/demo/README.md
+++ b/deploy/demo/README.md
@@ -1,0 +1,15 @@
+
+
+# Get Prom Adapter metrics:
+
+Prom Adapter is needed when scaling with k8s HPA.
+
+> kubectl get --raw /apis/custom.metrics.k8s.io/v1beta1
+
+# Get Keda Metrics
+
+Keda can be used in more powerful scenarios & does not require prom-adapter as it can query prometheus diretly.
+
+https://keda.sh/docs/2.15/operate/metrics-server/
+
+> kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1"

--- a/deploy/demo/camunda_v1alpha1_zeebeautoscaler.yaml
+++ b/deploy/demo/camunda_v1alpha1_zeebeautoscaler.yaml
@@ -1,6 +1,7 @@
 apiVersion: camunda.sijoma.dev/v1alpha1
 kind: ZeebeAutoscaler
 metadata:
-  name: zeebeautoscaler-sample
+  name: camunda-platform-zeebe
+  namespace: demo
 spec:
   replicas: 3

--- a/deploy/local/camunda/hpa-gateway.yaml
+++ b/deploy/local/camunda/hpa-gateway.yaml
@@ -1,0 +1,22 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hpa-zeebe-gateway
+  namespace: camunda-platform
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    name: camunda-platform-zeebe-gateway
+    kind: Deployment
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 30
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: 90

--- a/docs/zeebeautoscalers.camunda.sijoma.dev_sample.html
+++ b/docs/zeebeautoscalers.camunda.sijoma.dev_sample.html
@@ -53,55 +53,24 @@
                 <div class="collapse-group">
                     <details class="collapse-panel">
                         <div id="yaml-v1alpha1" class="collapse-content">
-                            <pre class="language-yaml"><code class="language-yaml"># APIVersion defines the versioned schema of this representation of an object.
-# Servers should convert recognized schemas to the latest internal value, and
-# may reject unrecognized values.
-# More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-apiVersion: camunda.sijoma.dev/v1alpha1
-# Kind is a string value representing the REST resource this object represents.
-# Servers may infer this from the endpoint the client submits requests to.
-# Cannot be updated.
-# In CamelCase.
-# More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            <pre class="language-yaml"><code class="language-yaml">apiVersion: camunda.sijoma.dev/v1alpha1
 kind: ZeebeAutoscaler
 metadata: {}
-# ZeebeAutoscalerSpec defines the desired state of ZeebeAutoscaler
 spec:
   replicas: 1
-  # ZeebeRef references that exists in the same namespace.
   zeebeRef:
     gateway:
-      port: 1
-      serviceName: string
-    # Name of the Zeebe statefulset to scale
-    name: string
-# ZeebeAutoscalerStatus defines the observed state of ZeebeAutoscaler
+      port: 9600
+      serviceName: &#34;camunda-platform-zeebe-gateway&#34;
+    name: &#34;camunda-platform-zeebe&#34;
 status:
-  # Conditions holds the information on the last operations on Zeebe that can be useful during scaling
   conditions:
   - lastTransitionTime: string
-    # message is a human readable message indicating details about the transition.
-    # This may be an empty string.
     message: string
-    # observedGeneration represents the .metadata.generation that the condition was set based upon.
-    # For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
-    # with respect to the current state of the instance.
     observedGeneration: 0
-    # reason contains a programmatic identifier indicating the reason for the condition&#39;s last transition.
-    # Producers of specific condition types may define expected values and meanings for this field,
-    # and whether the values are considered a guaranteed API.
-    # The value should be a CamelCase string.
-    # This field may not be empty.
-    reason: b # ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
-    # status of the condition, one of True, False, Unknown.
+    reason: yID_G # ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
     status: &#34;True&#34;
-    # type of condition in CamelCase or in foo.example.com/CamelCase.
-    # ---
-    # Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
-    # useful (see .node.status.conditions), the ability to deconflict is important.
-    # The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
-    type: twa2m7/iMV9 # ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
-  # ObservedGeneration is the last observed generation by the controller.
+    type: n2 # ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
   observedGeneration: 1
   replicas: 1
   selector: string
@@ -219,7 +188,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
     </summary>
     <div id="replicas" class="collapse-content">
         <div class="property-description">
-            <p></p>
+            <p>Replicas the number of Zeebe brokers to deploy</p>
         </div>
         <div class="collapse-group">
             
@@ -237,7 +206,7 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
         
         
         
-        <kbd class="text-primary">{&#34;gateway&#34;:{&#34;port&#34;:9600,&#34;serviceName&#34;:&#34;camunda-platform-zeebe-gateway&#34;},&#34;name&#34;:&#34;camunda-platform-zeebe&#34;}</kbd>
+        <kbd class="text-primary">{}</kbd>
         
         
     </summary>
@@ -255,6 +224,8 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
         gateway <kbd class="text-muted">object</kbd>
         
         
+        
+        <kbd class="text-primary">{}</kbd>
         
         
     </summary>
@@ -275,11 +246,13 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
         
         
         
+        <kbd class="text-primary">9600</kbd>
+        
         
     </summary>
     <div id="port" class="collapse-content">
         <div class="property-description">
-            <p></p>
+            <p>Port of the zeebe-gateway, needs to expose the management API</p>
         </div>
         <div class="collapse-group">
             
@@ -297,11 +270,13 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
         
         
         
+        <kbd class="text-primary">&#34;camunda-platform-zeebe-gateway&#34;</kbd>
+        
         
     </summary>
     <div id="serviceName" class="collapse-content">
         <div class="property-description">
-            <p></p>
+            <p>ServiceName of the zeebe-gateway, this is used to trigger scaling operations &amp; request topology information</p>
         </div>
         <div class="collapse-group">
             
@@ -325,6 +300,8 @@ More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-
         name <kbd class="text-muted">string</kbd>
         
         
+        
+        <kbd class="text-primary">&#34;camunda-platform-zeebe&#34;</kbd>
         
         
     </summary>


### PR DESCRIPTION
Just updated the API defaults:

Now not more than this is needed. 

```
apiVersion: camunda.sijoma.dev/v1alpha1
kind: ZeebeAutoscaler
metadata:
  name: zeebeautoscaler-sample
spec:
  replicas: 3
```

